### PR TITLE
Support reservations having many instances

### DIFF
--- a/typesense-multi-node/functions/instance-listener/index.js
+++ b/typesense-multi-node/functions/instance-listener/index.js
@@ -34,15 +34,15 @@ exports.handler = async () => {
         .promise()
         .then((res) => {
             res.Reservations.forEach((v) => {
-                if (v.Instances[0]) {
+                v.Instances.forEach((i) => {
                     nodeStrings.push(
-                        v.Instances[0].PrivateIpAddress +
+                        i.PrivateIpAddress +
                             ":" +
                             process.env.TypesensePeeringPort +
                             ":" +
                             process.env.TypesenseApiPort
                     );
-                }
+                });
             });
         })
         .catch((err) => {


### PR DESCRIPTION
This fixes a bug where there will be 3 instances, however only 2 show up in the node list because one reservation launched more than one instance, thus only two reservations returned.